### PR TITLE
Add sanity checks to not fire onClose for transport thats closed multiple times.

### DIFF
--- a/providers/core/peerconnection.unprivileged.js
+++ b/providers/core/peerconnection.unprivileged.js
@@ -482,8 +482,8 @@ PeerConnection.prototype.close = function (continuation) {
     return;
   }
   this.peer.close();
-  continuation();
   this.dispatchEvent("onClose");
+  continuation();
 };
 
 fdom.apis.register('core.peerconnection', PeerConnection);


### PR DESCRIPTION
Add sanity checks to not fire onClose for transport thats closed multiple times.
