### PR TITLE
Add secure method to tcp socket interface

### DIFF
--- a/interface/core.js
+++ b/interface/core.js
@@ -111,6 +111,16 @@ fdom.apis.set('core.tcpsocket', {
     }
   },
 
+  // Upgrades a socket to TLS, expected to be invoked after connect.
+  'secure': {
+    type: 'method',
+    value: [],
+    err: {
+      'errcode': 'string',
+      'message': 'string'
+    }
+  },
+
   // Write buffer data to a socket.
   // Fails with an error if write fails.
   'write': {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom",
   "description": "Embracing a distributed web",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "homepage": "http://freedomjs.org",
   "bugs": {
     "url": "http://github.com/freedomjs/freedom/issues",


### PR DESCRIPTION
Add secure method to tcp socket interface.  This will have separate implementations in chrome and firefox
