### PR TITLE
Make module config override default and use warn as default log level

### DIFF
--- a/demo/chat/index.html
+++ b/demo/chat/index.html
@@ -11,7 +11,7 @@
   {
     "strongIsolation": true,
     "stayLocal": true,
-    "debug": true
+    "debug": "debug"
   }
   </script>
   <script type='text/javascript' src='ux.js'></script>

--- a/demo/connections/index.html
+++ b/demo/connections/index.html
@@ -11,7 +11,7 @@
       data-manifest="manifest.json">
     {
       "stayLocal": true,
-      "debug": true
+      "debug": "debug"
     }
   </script>
   <script type="text/javascript">

--- a/demo/counter/index.html
+++ b/demo/counter/index.html
@@ -11,7 +11,7 @@
       data-manifest="manifest.json">
     {
       "stayLocal": true,
-      "debug": true,
+      "debug": "log",
       "strongIsolation": true
     }
   </script>

--- a/demo/customchannel/index.html
+++ b/demo/customchannel/index.html
@@ -8,7 +8,7 @@
       data-manifest="manifest.json">
 {
   "stayLocal": true,
-  "debug": true,
+  "debug": "debug",
   "strongIsolation": true
 }
   </script>

--- a/demo/filedrop/index.html
+++ b/demo/filedrop/index.html
@@ -11,7 +11,6 @@
       data-manifest="manifest.json">
     {
       "stayLocal": true,
-      "debug": false,
       "strongIsolation": true
     }
   </script>

--- a/src/entry.js
+++ b/src/entry.js
@@ -39,7 +39,7 @@ fdom.setup = function (global, freedom_src, config) {
 
   if (site_cfg.moduleContext) {
     if (config) {
-      fdom.util.mixin(config, site_cfg, true);
+      fdom.util.mixin(site_cfg, config, true);
     }
     site_cfg.global = global;
     site_cfg.src = freedom_src;


### PR DESCRIPTION
Fixes https://github.com/freedomjs/freedom/issues/99

Makes demo's have string-values for their log level instead of (misleading) booleans. :)

TESTED: 
grunt test
ran demo counter and chat apps from demo's folder. 
ran sample app from uproxy-lib, tried different log levels. 
