### PR TITLE
Refactor frame link to allow override of document.

### DIFF
--- a/src/link/frame.js
+++ b/src/link/frame.js
@@ -12,6 +12,7 @@ var util = require('../util');
  */
 var Frame = function(id, resource) {
   Link.call(this, id, resource);
+  this.getDocument();
 };
 
 /**


### PR DESCRIPTION
The freedom-for-firefox backgroundFrame alternative can be greatly simplified by allowing just the document property to be overridden, instead of trying to keep the `makeFrame` and `setupFrame` functions synchronized.
