### PR TITLE
Fix getStats and add an integration test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "karma-sauce-launcher": "~0.2.8",
     "karma-story-reporter": "^0.2.2",
     "karma-unicorn-reporter": "^0.1.4",
-    "webrtc-adapter": "0.0.3"
+    "webrtc-adapter": "0.0.4"
   },
   "scripts": {
     "test": "grunt ci --verbose",

--- a/providers/core/core.rtcpeerconnection.js
+++ b/providers/core/core.rtcpeerconnection.js
@@ -147,8 +147,8 @@ RTCPeerConnectionAdapter.prototype.createDataChannel = function (label, dataChan
   callback(id);
 };
 
-RTCPeerConnectionAdapter.prototype.getStats = function (callback) {
-  this.connection.getStats(callback, callback.bind(this, undefined));
+RTCPeerConnectionAdapter.prototype.getStats = function (selector, callback) {
+  this.connection.getStats(selector, callback, callback.bind(this, undefined));
 };
 
 RTCPeerConnectionAdapter.prototype.ondatachannel = function (event) {


### PR DESCRIPTION
This change also fixes a typo in the data channel integration test
and increments the webrtc-adapter dependency to the latest version,
which includes standardization of the getStats output format.

Note: this cannot be merged until after https://github.com/willscott/webrtc-adapter/pull/1 , because webrtc-adapter version 0.0.4 does not yet exist.
