### PR TITLE
Update the RTCPeerConnection interface to the new RTCOfferOptions.

### DIFF
--- a/interface/core.rtcpeerconnection.json
+++ b/interface/core.rtcpeerconnection.json
@@ -19,17 +19,10 @@
 
     // Per http://w3c.github.io/webrtc-pc/#idl-def-RTCOfferOptions
     "createOffer": {"type": "method", "value": [{
-      "mandatory": {
-        "OfferToReceiveAudio": "number",
-        "OfferToReceiveVideo": "number"
-      }, "optional": ["array",{
-        "OfferToReceiveAudio": "number",
-        "OfferToReceiveVideo": "number",
-        "IceRestart": "boolean",
-        "VoiceActivityDetection": "boolean",
-        "DtlsSrtpKeyAgreement": "boolean",
-        "RtpDataChannels": "boolean"
-      }]
+      "offerToReceiveAudio": "number",
+      "offerToReceiveVideo": "number",
+      "iceRestart": "boolean",
+      "voiceActivityDetection": "boolean"
     }], "ret": {
       "type": "string",
       "sdp": "string"


### PR DESCRIPTION
Technically this is an API break but I'm pretty sure no one is using this yet.  I've inspected the source code of Chromium and Firefox, and confirmed that both now support this new syntax.
