### PR TITLE
make localpage auth not an option for async loaded freedom

### DIFF
--- a/providers/oauth/oauth.localpageauth.js
+++ b/providers/oauth/oauth.localpageauth.js
@@ -11,6 +11,7 @@ var loadedOnStartup = false;
 if (typeof window !== 'undefined' && window && window.location &&
     window.addEventListener) {
   window.addEventListener('load', function () {
+    "use strict";
     loadedOnStartup = true;
   }, true);
 


### PR DESCRIPTION
Restored previous functionality.
