### PR TITLE
add missing buffer field to core.rtcdatachannel onmessage event

### DIFF
--- a/interface/core.rtcdatachannel.json
+++ b/interface/core.rtcdatachannel.json
@@ -25,8 +25,7 @@
     "close": {"type": "method", "value": []},
     "onmessage": {"type": "event", "value": {
       "text": "string",
-      "buffer": "buffer",
-      "binary": "buffer"
+      "buffer": "buffer"
     }},
     "getBinaryType": {"type": "method", "value": [], "ret": "string"},
     "setBinaryType": {"type": "method", "value": ["string"]},


### PR DESCRIPTION
Results in empty messages :-)

Should I change the version number in `package.json` too?
