### PR TITLE
Track bundle size.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -412,7 +412,8 @@ module.exports = function (grunt) {
         'gitinfo',
         'karma:saucelabs',
         'coveralls:report',
-        'dynamic_codeclimate'
+        'dynamic_codeclimate',
+        'reportStats'
       ]);
     } else {  //When run from Travis from jobs *.2, *.3, etc.
       grunt.registerTask('ci', [

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "karma-story-reporter": "^0.2.2",
     "karma-unicorn-reporter": "^0.1.4",
     "node-json-minify": "^0.1.3-a",
+    "request": "^2.51.0",
     "webrtc-adapter": "^0.0.5"
   },
   "scripts": {

--- a/tasks/publishWebsite.js
+++ b/tasks/publishWebsite.js
@@ -6,7 +6,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('publishWebsite', 'Publishes to freedomjs.org.', function () {
     var done = this.async();
-    child_process.execFile('tasks/scripts/publishWebsite.sh', [], function(err, stdout, stderr) {
+    child_process.execFile('tasks/scripts/publishWebsite.sh', [], function (err, stdout, stderr) {
       if (err !== null) { grunt.log.error(err); }
       if (stdout) { grunt.log.writeln('out: ' + stdout.toString()); }
       if (stderr) { grunt.log.error('err: ' + stderr.toString()); }

--- a/tasks/report-stats.js
+++ b/tasks/report-stats.js
@@ -1,0 +1,38 @@
+/*jslint node:true */
+
+/**
+ * This task saves the following output statistics from continuous integration
+ * so that they can be tracked between builds:
+ * * Artifact size of freedom.js
+ * * Build time
+ * * Commit
+ * * Branch
+ */
+module.exports = function (grunt) {
+  'use strict';
+  var request = require('request'),
+    fs = require('fs'),
+    start = new Date();
+
+  grunt.registerTask('reportStats', 'Report build statistics.', function () {
+    var done = this.async(),
+      size = fs.statSync('freedom.js').size;
+
+    request({
+      url: 'https://script.google.com/macros/s/' +
+            'AKfycbyssdIXai4pthm-mikC-jrUYUjGKzVmV-NgIVilIv9dJPcvRaU/exec',
+      qs: {
+        time: new Date() - start,
+        size: size,
+        commit: process.env.TRAVIS_COMMIT,
+        branch: process.env.TRAVIS_BRANCH,
+        failures: 0,
+        freedom: process.env.STAT_KEY
+      }
+    }, function (err, response) {
+      if (err !== null) { grunt.fail.warn(err); }
+      grunt.log.writeln('Reported file size of ' + size + ' to freedomjs.org!');
+      done();
+    });
+  });
+};

--- a/tasks/report-stats.js
+++ b/tasks/report-stats.js
@@ -7,6 +7,13 @@
  * * Build time
  * * Commit
  * * Branch
+ * Statistics are collected in:
+ * https://docs.google.com/spreadsheets/d/1f3aL376-FKWGYOh2lpHTwELL9kfzZjcp668k-gZU6Ug/edit?usp=sharing
+ * via the appscript at:
+ * https://script.google.com/d/1vsdAkMWx_zB30TJAGDtEtiG8rcvwEA0QBfdBBjhHoXue_jYkx8Z4jTPf/edit?usp=sharing
+ *
+ * Statistics are authenticated by the appscript by checking the presence of the
+ * STAT_KEY variable, which is saved in Travis CI as an environmental variable.
  */
 module.exports = function (grunt) {
   'use strict';


### PR DESCRIPTION
Resolve #161

This saves to a spreadsheet that we can then build graphs off of. Tracks file size of freedom.js (non-minimized) & build time on travis.