### PR TITLE
dispatch blob messages as arraybuffers

### DIFF
--- a/providers/core/core.rtcdatachannel.js
+++ b/providers/core/core.rtcdatachannel.js
@@ -6,10 +6,6 @@ var unAttachedChannels = {};
 var allocateChannel = function (dataChannel) {
   var id = util.getId();
   unAttachedChannels[id] = dataChannel;
-
-  // Default binaryType in Firefox is 'blob'.
-  dataChannel.binaryType = 'arraybuffer';
-
   return id;
 };
 
@@ -159,8 +155,7 @@ RTCDataChannelAdapter.prototype.onmessage = function (event) {
     this.dispatchEvent('onmessage', {text: event.data});
   } else if (event.data instanceof ArrayBuffer) {
     this.dispatchEvent('onmessage', {buffer: event.data});
-  } else if (event.data instanceof Blob &&
-      this.channel.binaryType === 'arraybuffer') {
+  } else if (event.data instanceof Blob) {
     // Workaround for setBinaryType strangeness in Firefox add-ons:
     //   https://bugzilla.mozilla.org/show_bug.cgi?id=1122682
     myBlobToArrayBuffer(event.data, function(buffer) {

--- a/providers/core/core.rtcdatachannel.js
+++ b/providers/core/core.rtcdatachannel.js
@@ -6,6 +6,10 @@ var unAttachedChannels = {};
 var allocateChannel = function (dataChannel) {
   var id = util.getId();
   unAttachedChannels[id] = dataChannel;
+
+  // Default binaryType in Firefox is 'blob'.
+  dataChannel.binaryType = 'arraybuffer';
+
   return id;
 };
 
@@ -155,7 +159,8 @@ RTCDataChannelAdapter.prototype.onmessage = function (event) {
     this.dispatchEvent('onmessage', {text: event.data});
   } else if (event.data instanceof ArrayBuffer) {
     this.dispatchEvent('onmessage', {buffer: event.data});
-  } else if (event.data instanceof Blob) {
+  } else if (event.data instanceof Blob &&
+      this.channel.binaryType === 'arraybuffer') {
     // Workaround for setBinaryType strangeness in Firefox add-ons:
     //   https://bugzilla.mozilla.org/show_bug.cgi?id=1122682
     myBlobToArrayBuffer(event.data, function(buffer) {

--- a/spec/providers/coreIntegration/rtcpeerconnection.integration.src.js
+++ b/spec/providers/coreIntegration/rtcpeerconnection.integration.src.js
@@ -17,14 +17,14 @@ module.exports = function (pc, dc, setup) {
   // Establishes a peerconnection with one datachannel, sends a message on the
   // datachannel and calls back with the message received by the other peer.
   var sendMessageToPeer = function(payload, callback) {
-    var alice, bob, aliceChannel, bobchannel,
+    var alice, bob, aliceChannel, bobChannel,
       aliceCandidates = [],
       aliceOffer;
     alice = peercon();
     bob = peercon();
     bob.on('ondatachannel', function (msg) {
-      bobchannel = datachan(msg.channel);
-      bobchannel.on('onmessage', function (msg) {
+      bobChannel = datachan(msg.channel);
+      bobChannel.on('onmessage', function (msg) {
         alice.close();
         bob.close();
         callback(msg);

--- a/spec/providers/coreIntegration/rtcpeerconnection.integration.src.js
+++ b/spec/providers/coreIntegration/rtcpeerconnection.integration.src.js
@@ -26,9 +26,9 @@ module.exports = function (pc, dc, setup) {
     bob.on('ondatachannel', function (msg) {
       bobchannel = datachan(msg.channel);
       bobchannel.on('onmessage', function (msg) {
-        callback(msg);
         alice.close();
         bob.close();
+        callback(msg);
       });
     });
     bob.on('onicecandidate', function (msg) {


### PR DESCRIPTION
Dispatches messages received as Blobs as ArrayBuffers, to work around the following issue in Firefox add-ons:
https://bugzilla.mozilla.org/show_bug.cgi?id=1122682

Depends on:
 * https://github.com/willscott/webrtc-adapter/pull/3
 * https://github.com/freedomjs/freedom-for-firefox/pull/45