### PR TITLE
fix tcp integration to avoid tests clobbering each others connections

### DIFF
--- a/spec/providers/coreIntegration/tcpsocket.integration.src.js
+++ b/spec/providers/coreIntegration/tcpsocket.integration.src.js
@@ -1,10 +1,12 @@
 /*jslint node:true,bitwise:true*/
 /*globals Uint8Array, beforeEach, afterEach, it, expect, jasmine */
 var testUtil = require('../../util');
+var PromiseCompat = require('es6-promise').Promise
 
 module.exports = function (provider, setup) {
   'use strict';
   var socket, dispatch;
+
   beforeEach(function () {
     setup();
     dispatch = testUtil.createTestPort('msgs');
@@ -31,7 +33,7 @@ module.exports = function (provider, setup) {
         console.warn('received onData');
         expect(written).toBe(true);
         expect(dispatch.gotMessage('onData', [])).not.toEqual(false);
-        socket.close(function () { done(); });
+        socket.close(done);
       });
     });
   });
@@ -42,9 +44,10 @@ module.exports = function (provider, setup) {
       onconnect = function () {
         client.getInfo(function (info) {
           expect(info.localPort).toBeGreaterThan(1023);
-          client.close(function () {});
-          socket.close(function () {});
-          done();
+          PromiseCompat.all([
+            client.close(function () {}),
+            socket.close(function () {}),
+            done()]);
         });
       };
 
@@ -70,10 +73,11 @@ module.exports = function (provider, setup) {
       }
       expect(evt).toEqual('onData');
       expect(msg.data.byteLength).toEqual(10);
-      socket.close(function () {});
-      client.close(function () {});
-      receiver.close(function () {});
-      done();
+      PromiseCompat.all([
+        socket.close(function () {}),
+        client.close(function () {}),
+        receiver.close(function () {}),
+        done()]);
     };
     dispatch.gotMessageAsync('onConnection', [], function (msg) {
       console.warn('connection');

--- a/spec/providers/coreIntegration/tcpsocket.integration.src.js
+++ b/spec/providers/coreIntegration/tcpsocket.integration.src.js
@@ -23,14 +23,11 @@ module.exports = function (provider, setup) {
 
   it("Works as a Client", function (done) {
     socket.connect('www.google.com', 80, function () {
-      console.warn('connected');
       var written = false;
       socket.write(rawStringToBuffer('GET / HTTP/1.0\n\n'), function (okay) {
-        console.warn('written');
         written = true;
       });
       dispatch.gotMessageAsync('onData', [], function(msg) {
-        console.warn('received onData');
         expect(written).toBe(true);
         expect(dispatch.gotMessage('onData', [])).not.toEqual(false);
         socket.close(done);
@@ -80,18 +77,14 @@ module.exports = function (provider, setup) {
         done()]);
     };
     dispatch.gotMessageAsync('onConnection', [], function (msg) {
-      console.warn('connection');
       expect(msg.socket).toBeDefined();
       receiver = new provider.provider(undefined, onDispatch, msg.socket);
-      console.log('new socket id', msg);
     });
     onconnect = function () {
-      console.warn('connected');
       var buf = new Uint8Array(10);
       client.write(buf.buffer, function () {});
     };
     socket.listen('127.0.0.1', 9981, function () {
-      console.warn('listening');
       client = new provider.provider(undefined, cspy);
       client.connect('127.0.0.1', 9981, onconnect);
     });

--- a/spec/providers/coreIntegration/tcpsocket.integration.src.js
+++ b/spec/providers/coreIntegration/tcpsocket.integration.src.js
@@ -27,12 +27,12 @@ module.exports = function (provider, setup) {
         console.warn('written');
         written = true;
       });
-      setTimeout(function () {
+      dispatch.gotMessageAsync('onData', [], function(msg) {
+        console.warn('received onData');
         expect(written).toBe(true);
         expect(dispatch.gotMessage('onData', [])).not.toEqual(false);
-        done();
-        socket.close(function () {});
-      }, 500);
+        socket.close(function () { done(); });
+      });
     });
   });
 
@@ -70,10 +70,10 @@ module.exports = function (provider, setup) {
       }
       expect(evt).toEqual('onData');
       expect(msg.data.byteLength).toEqual(10);
-      done();
       socket.close(function () {});
       client.close(function () {});
       receiver.close(function () {});
+      done();
     };
     dispatch.gotMessageAsync('onConnection', [], function (msg) {
       console.warn('connection');
@@ -100,5 +100,6 @@ module.exports = function (provider, setup) {
         done();
       });
   });
+
   // TODO: add tests for tcpsocket.secure, accepting multiple.
 };


### PR DESCRIPTION
A better approach - it turns out that, for grunt-jasmine-node2 at least, the three socket-using tests end up clobbering each other (connection reset error) as they were formulated. I cleaned up the "Works as a Client" test a bit as was discussed, but that wasn't the core issue - I think it had more to do with the done() being invoked before the various close() calls in "Sends from Client to Server".

In any case, this passes now, let me know thoughts - thanks!