### PR TITLE
Soycode tcpintegration

### DIFF
--- a/interface/core.tcpsocket.json
+++ b/interface/core.tcpsocket.json
@@ -37,9 +37,9 @@
       "INVALID_ARGUMENT": "Invalid argument",
       // Connection timed out.
       "TIMED_OUT": "Timed out",
-      // Operation cannot complete because socket is not connected.
+      // Operation cannot complete because socket is not connected
       "NOT_CONNECTED": "Socket not connected",
-      // Socket reset because of change in network state.
+      // Socket reset because of change in network state
       "NETWORK_CHANGED": "Network changed",
       // Connection closed
       "CONNECTION_CLOSED": "Connection closed gracefully",
@@ -55,8 +55,10 @@
       "INTERNET_DISCONNECTED": "Cannot reach any network",
       // The IP address is not correctly formed.
       "ADDRESS_INVALID": "Invalid address",
-      // The IP address is unreachable.
-      "ADDRESS_UNREACHABLE": "No route to host"
+      // The IP address is unreachable
+      "ADDRESS_UNREACHABLE": "No route to host",
+      // SOCKS proxy server could not reach host
+      "HOST_UNREACHABLE": "SOCKS proxy server could not reach host"
     }},
     
     // Close a socket. Will Fail if the socket is not connected or already

--- a/spec/providers/coreIntegration/tcpsocket.integration.src.js
+++ b/spec/providers/coreIntegration/tcpsocket.integration.src.js
@@ -131,7 +131,7 @@ module.exports = function (provider, setup) {
     });
     socket.listen('127.0.0.1', 9981, function () {
       client = new provider.provider(undefined, cspy);
-      client.connect('127.0.0.1', 9981, function () { });//client.close(); });
+      client.connect('127.0.0.1', 9981, function () { });
     });
   });
 
@@ -233,5 +233,27 @@ module.exports = function (provider, setup) {
     });
   });
 
-  // TODO: add tests for tcpsocket.secure, accepting multiple.
+  it("Socket reusing id of closed socket is also closed", function(done) {
+    var cspy = jasmine.createSpy('client'),
+        client,
+        socketCopy;
+
+    dispatch.gotMessageAsync('onConnection', [], function (msg) {
+      expect(msg.socket).toBeDefined();
+      client.close(function () {
+        socketCopy = new provider.provider(undefined, function () {},
+                                           msg.socket);
+        socketCopy.getInfo(function (info) {
+          // TODO consider changing implementation to give more explicit failure
+          expect(info.connected).toEqual(false);
+          done();
+        });
+      });
+    });
+    socket.listen('127.0.0.1', 9981, function () {
+      client = new provider.provider(undefined, cspy);
+      client.connect('127.0.0.1', 9981, function () {});
+    });
+
+  });
 };

--- a/spec/providers/coreIntegration/tcpsocket.integration.src.js
+++ b/spec/providers/coreIntegration/tcpsocket.integration.src.js
@@ -189,24 +189,21 @@ module.exports = function (provider, setup) {
 
   it("Errors when securing a disconnected socket", function(done) {
     socket.secure(function (success, err) {
-      var allowedErrors = ['NOT_CONNECTED', 'SOCKET_NOT_CONNECTED'];
-      expect(allowedErrors).toContain(err.errcode);
+      expect(err.errcode).toEqual('NOT_CONNECTED');
       done();
     });
   });
 
   it("Errors when writing a disconnected socket", function(done) {
     socket.write(rawStringToBuffer(''), function (success, err) {
-      var allowedErrors = ['NOT_CONNECTED', 'SOCKET_NOT_CONNECTED'];
-      expect(allowedErrors).toContain(err.errcode);
+      expect(err.errcode).toEqual('NOT_CONNECTED');
       done();
     });
   });
 
   it("Errors when closing a disconnected socket", function(done) {
     socket.close(function (success, err) {
-      var allowedErrors = ['SOCKET_CLOSED'];
-      expect(allowedErrors).toContain(err.errcode);
+      expect(err.errcode).toEqual('SOCKET_CLOSED');
       done();
     });
   });
@@ -214,10 +211,7 @@ module.exports = function (provider, setup) {
   it("Errors when listening on an already allocated socket", function(done) {
     socket.listen('127.0.0.1', 9981, function () {
       socket.listen('127.0.0.1', 9981, function (success, err) {
-        // TODO - consider removing 'UNKNOWN' as allowed error
-        // (currently in use in freedom-for-firefox provider)
-        var allowedErrors = ['ALREADY_CONNECTED', 'UNKNOWN'];
-        expect(allowedErrors).toContain(err.errcode);
+        expect(err.errcode).toEqual('ALREADY_CONNECTED');
         socket.close(done);
       });
     });

--- a/spec/providers/coreIntegration/tcpsocket.integration.src.js
+++ b/spec/providers/coreIntegration/tcpsocket.integration.src.js
@@ -176,25 +176,14 @@ module.exports = function (provider, setup) {
   });
 
   it("Secures a socket", function (done) {
+    // TODO - prepareSecure test, if Chrome isn't fixing that soon
     socket.connect('www.google.com', 443, function () {
-      var prepared;
-      // prepareSecure is Chrome specific, see freedom-for-chrome
-      socket.prepareSecure(function () {
-        prepared = true;
-      });
-      // TODO: timeout approach sucks, preferred approach:
-      // https://github.com/freedomjs/freedom/wiki/prepareSecure-API-Usage
-      // But right now:
-      // a) dispatch isn't receiving the message specified by wiki
-      // b) non-chrome providers won't receive the message either
-      // Overall it's still unclear if secure is behaving as expected here
-      // Hopefully eventually prepareSecure isn't needed, simplifying this test
-      setTimeout(function () {
-        expect(prepared).toEqual(true);
-        socket.secure(function () {
+      socket.secure(function() {
+        socket.getInfo(function (info) {
+          expect(info.connected).toEqual(true);
           socket.close(done);
         });
-      }, 1000);
+      });
     });
   });
 

--- a/spec/providers/coreIntegration/tcpsocket.integration.src.js
+++ b/spec/providers/coreIntegration/tcpsocket.integration.src.js
@@ -127,7 +127,7 @@ module.exports = function (provider, setup) {
       onConnectionReceived = true;
       expect(msg.socket).toBeDefined();
       receiver = new provider.provider(undefined, onDispatch, msg.socket);
-      client.close();
+      client.close(function () {});
     });
     socket.listen('127.0.0.1', 9981, function () {
       client = new provider.provider(undefined, cspy);


### PR DESCRIPTION
Meant to fix #128 and currently passes in freedom-for-chrome. Doesn't completely pass in freedom-for-firefox (but neither do the integration tests in general), and the jasmine_node task is more generally failing for me right now in freedom-for-node. Besides investigating that, main todos:

- Clarify whether some calls really should give an error or not (e.g. getInfo on a closed socket)
- Consider making error messages consistent across providers (e.g. 'NOT_CONNECTED' in Chrome versus 'SOCKET_NOT_CONNECTED' in Firefox) - if these differences reflect actual underlying differences in the browsers themselves then maybe keep them
- Implement the remaining tests, in particular more tests around using 'secure' (which only seems to be implemented in Chrome, so the test may need some conditionality to avoid running in other providers)

Overall this pull request isn't ready for real review yet, but eyes and thoughts are welcome if you're interested, else this is just for my reference and I'll update as I progress.