### PR TITLE
fix core.console source field formatting and simplify

### DIFF
--- a/providers/core/core.console.js
+++ b/providers/core/core.console.js
@@ -48,29 +48,28 @@ Logger_console.prototype.print = function (severity, source, msg) {
     return;
   }
   
-  if (typeof process !== 'undefined' &&
-      {}.toString.call(process) === '[object process]' && source) {
-    arr.unshift('\x1B[39m');
-    arr.unshift('\x1B[31m' + source);
-    /*jslint nomen: true*/
-    // Firefox in JSM context.
-    // see: http://mxr.mozilla.org/mozilla-release/source/toolkit/devtools/Console.jsm
-    } else if (this.console.maxLogLevel && source) {
+  if (source) {
+    if (typeof process !== 'undefined' &&
+        {}.toString.call(process) === '[object process]') {
+      // Node.
+      arr.unshift('\x1B[39m');
+      arr.unshift('\x1B[31m' + source);
+    } else if (this.console.maxLogLevel) {
+      // Firefox in JSM context:
+      //   http://mxr.mozilla.org/mozilla-release/source/toolkit/devtools/Console.jsm
       if (!this.console.freedomDump) {
         this.console.freedomDump = this.console.dump;
         this.console.dump = function() {};
       }
-      this.console.freedomDump('{' + source + '}.' + severity + ': ' +
+      this.console.freedomDump(source + ' ' + severity[0].toUpperCase() + ' ' +
           arr.join(' ') + '\n');
-      arr.unshift(source.toUpperCase());
-  // Firefox in browser context.
-  } else if (this.console.__mozillaConsole__ && source) {
-    arr.unshift(source.toUpperCase());
-    /*jslint nomen: false*/
-  } else if (source) {
-    arr.unshift('color: red');
-    arr.unshift('%c ' + source);
+    } else {
+      arr.unshift('color: none');
+      arr.unshift('color: red');
+      arr.unshift('%c' + source + '%c');
+    }
   }
+
   if (!this.console[severity] && this.console.log) {
     severity = 'log';
   }


### PR DESCRIPTION
Two main changes:
 1. reset the text colour after printing the module name
 1. make the Firefox JSM log format more like we get in the browser, viz. `module X message`, where `module` is the module name, `X` indicates the level, and `message` is the message.

AFAICT, only the Firefox JSM environment needs special-casing: I tested this on Chrome and Firefox web and add-on environments, plus Firefox's Browser Console.