### PR TITLE
temporarily pin grunt-browserify version to fix sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "browserify-istanbul": "^0.1.2",
     "es5-shim": "^4.0.0",
     "es6-promise": "^2.0.0",
-    "grunt-browserify": "^3.2.0",
+    "grunt-browserify": "3.7.0",
     "grunt-bump": "0.0.15",
     "grunt-codeclimate-reporter": "^1.0.0",
     "grunt-contrib-clean": "~0.6.0",


### PR DESCRIPTION
(Hack) Fix #276 

The real fix is for the various dependencies to deal properly with unicode, as documented in the issue. I briefly toyed with changing our build process to temporarily remove comments etc. etc. but decided this was a more parsimonious approach for the time being.