### PR TITLE
update grunt-bump, align versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "freedom",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "homepage": "http://freedomjs.org",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "es5-shim": "^4.0.0",
     "es6-promise": "^2.0.0",
     "grunt-browserify": "3.7.0",
-    "grunt-bump": "0.0.15",
+    "grunt-bump": "^0.3.1",
     "grunt-codeclimate-reporter": "^1.0.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-concat": "^0.5.0",


### PR DESCRIPTION
Noticed grunt-bump was pinned, looks like it doesn't have to be. No API changes that affect our specified options, the main new thing seems to be the ability to run `grunt bump --dry-run` to have it print what it will do without actually doing it (which is rather nice actually). While doing so I also noticed that the versions in package.json and bower.json are in disagreement, so fixing that here as well.