### PR TITLE
Add interactive param to oauth provider

### DIFF
--- a/interface/core.oauth.json
+++ b/interface/core.oauth.json
@@ -5,9 +5,9 @@
      * Indicate the intention to initiate an oAuth flow, allowing an appropriate
      * oAuth provider to begin monitoring for redirection.
      * This will generate a token, which must be passed to the single subsequent call
-     * to launchAuthFlow. 
-     * 
-     * 
+     * to launchAuthFlow.
+     *
+     *
      * @method initiateOAuth
      * @param {String[]} Valid oAuth redirect URIs for your application
      * @return {{redirect: String, state: String}} A chosen redirect URI and
@@ -25,7 +25,7 @@
         "message": "string"
       }
     },
-  
+
     /**
      * oAuth client-side flow - launch the provided URL
      * This must be called after initiateOAuth with the returned state object
@@ -37,10 +37,11 @@
      */
     "launchAuthFlow": {
       "type": "method",
-      "value": ["string", {
-        "redirect": "string",
-        "state": "string"
-      }],
+      "value": [
+        "string",
+        {"redirect": "string", "state": "string"},
+        "boolean"
+      ],
       "ret": "string",
       "err": {
         "errcode": "string",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom",
   "description": "Embracing a distributed web",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "homepage": "http://freedomjs.org",
   "bugs": {
     "url": "http://github.com/freedomjs/freedom/issues",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom",
   "description": "Embracing a distributed web",
-  "version": "0.6.26",
+  "version": "0.6.25",
   "homepage": "http://freedomjs.org",
   "bugs": {
     "url": "http://github.com/freedomjs/freedom/issues",

--- a/providers/core/core.oauth.js
+++ b/providers/core/core.oauth.js
@@ -100,7 +100,9 @@ OAuth.prototype.launchAuthFlow = function(authUrl, stateObj, interactive,
     });
     return;
   }
-
+  if (interactive === undefined) {
+    interactive = true;
+  }
   this.ongoing[stateObj.state].launchAuthFlow(
       authUrl, stateObj, interactive, continuation);
   delete this.ongoing[stateObj.state];

--- a/providers/core/core.oauth.js
+++ b/providers/core/core.oauth.js
@@ -87,10 +87,12 @@ OAuth.prototype.initiateOAuth = function (redirectURIs, continuation) {
  * @method launchAuthFlow
  * @param {String} authUrl - The URL that initiates the auth flow.
  * @param {Object.<string, string>} stateObj - The return value from initiateOAuth
+ * @param {Boolean} interactive - Whether to launch an interactive OAuth flow
  * @param {Function} continuation - Function to call when complete
  *    Expected to see a String value that is the response Url containing the access token
  */
-OAuth.prototype.launchAuthFlow = function(authUrl, stateObj, continuation) {
+OAuth.prototype.launchAuthFlow = function(authUrl, stateObj, interactive,
+                                          continuation) {
   if (!this.ongoing.hasOwnProperty(stateObj.state)) {
     continuation(undefined, {
       'errcode': 'UNKNOWN',
@@ -99,7 +101,8 @@ OAuth.prototype.launchAuthFlow = function(authUrl, stateObj, continuation) {
     return;
   }
 
-  this.ongoing[stateObj.state].launchAuthFlow(authUrl, stateObj, continuation);
+  this.ongoing[stateObj.state].launchAuthFlow(
+      authUrl, stateObj, interactive, continuation);
   delete this.ongoing[stateObj.state];
 };
 

--- a/providers/core/core.oauth.js
+++ b/providers/core/core.oauth.js
@@ -87,7 +87,8 @@ OAuth.prototype.initiateOAuth = function (redirectURIs, continuation) {
  * @method launchAuthFlow
  * @param {String} authUrl - The URL that initiates the auth flow.
  * @param {Object.<string, string>} stateObj - The return value from initiateOAuth
- * @param {Boolean} interactive - Whether to launch an interactive OAuth flow
+ * @param {Boolean} interactive - Whether to launch an interactive OAuth flow.
+ *    Defaults to true.
  * @param {Function} continuation - Function to call when complete
  *    Expected to see a String value that is the response Url containing the access token
  */

--- a/providers/oauth/oauth.localpageauth.js
+++ b/providers/oauth/oauth.localpageauth.js
@@ -65,10 +65,11 @@ LocalPageAuth.prototype.initiateOAuth = function(redirectURIs, continuation) {
  * @method launchAuthFlow
  * @param {String} authUrl - The URL that initiates the auth flow.
  * @param {Object.<string, string>} stateObj - The return value from initiateOAuth
+ * @param {Boolean} interactive - Whether to launch an interactive flow (ignored)
  * @param {Function} continuation - Function to call when complete
  *    Expected to see a String value that is the response Url containing the access token
  */
-LocalPageAuth.prototype.launchAuthFlow = function(authUrl, stateObj, continuation) {
+LocalPageAuth.prototype.launchAuthFlow = function(authUrl, stateObj, interactive, continuation) {
   "use strict";
   var listener = this.storageListener.bind(this, continuation, stateObj);
   this.listeners[stateObj.state] = listener;

--- a/providers/oauth/oauth.remotepageauth.js
+++ b/providers/oauth/oauth.remotepageauth.js
@@ -47,10 +47,11 @@ RemotePageAuth.prototype.initiateOAuth = function(redirectURIs, continuation) {
  * @method launchAuthFlow
  * @param {String} authUrl - The URL that initiates the auth flow.
  * @param {Object.<string, string>} stateObj - The return value from initiateOAuth
+ * @param {Boolean} interactive - Whether to launch an interactive flow (ignored)
  * @param {Function} continuation - Function to call when complete
  *    Expected to see a String value that is the response Url containing the access token
  */
-RemotePageAuth.prototype.launchAuthFlow = function(authUrl, stateObj, continuation) {
+RemotePageAuth.prototype.launchAuthFlow = function(authUrl, stateObj, interactive, continuation) {
   "use strict";
   var frame = global.document.createElement('iframe');
   frame.src = stateObj.redirect;

--- a/spec/providers/core/oauth.unit.spec.js
+++ b/spec/providers/core/oauth.unit.spec.js
@@ -14,7 +14,7 @@ MockProvider.prototype.initiateOAuth = function(redirectURIs, cont) {
   return true;
 };
 
-MockProvider.prototype.launchAuthFlow = function(authUrl, stateObj, cont) {
+MockProvider.prototype.launchAuthFlow = function(authUrl, stateObj, interactive, cont) {
   cont("Response Url");
   return true;
 };
@@ -40,7 +40,7 @@ describe('oAuth', function () {
         redirect: "http://localhost/oAuthRedirect",
         state: jasmine.any(Number)
       }));
-      authProvider.launchAuthFlow("AUTH URL", stateObj, callbackTwo);
+      authProvider.launchAuthFlow("AUTH URL", stateObj, true, callbackTwo);
     };
 
     var callbackTwo = function(respUrl) {
@@ -70,7 +70,7 @@ describe('oAuth', function () {
       });
     });
   });
-  
+
   afterEach(function () {
     oAuth.reset();
   });


### PR DESCRIPTION
This is part of a group of pull requests that add a new "interactive" param to the core.oauth launchAuthFlow API.  If this interactive param is false, Chrome + Firefox oauth tabs should open in the background (not be focused).  This results in a better reconnect UX for Facebook.

Related pull requests:
* https://github.com/uProxy/uproxy/pull/1698
* https://github.com/freedomjs/freedom-social-firebase/pull/29
* https://github.com/freedomjs/freedom-for-firefox/pull/70
* https://github.com/freedomjs/freedom-for-chrome/pull/78