### PR TITLE
Add new oauth integration test for interactive=false case

### DIFF
--- a/spec/providers/coreIntegration/oauth.integration.src.js
+++ b/spec/providers/coreIntegration/oauth.integration.src.js
@@ -4,37 +4,41 @@ module.exports = function (oa, pageauths, redirectURIs, setup) {
   'use strict';
   var oauth;
   var clientId = "513137528418-i52cg29ug3qjiqta1ttcvrguhrjjq2so.apps.googleusercontent.com";
+  var oldJasmineDefaultTimeoutInterval;
 
   beforeEach(function () {
     setup();
     oa.register(pageauths);
     oauth = testUtil.directProviderFor(oa.provider.bind(oa.provider, {}), testUtil.getApis().get(oa.name).definition);
+    oldJasmineDefaultTimeoutInterval = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 6000;
   });
 
   afterEach(function () {
     oa.reset();
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = oldJasmineDefaultTimeoutInterval;
   });
 
   it("Generates a token", function (done) {
     var o = oauth();
-    
+
     o.initiateOAuth(redirectURIs).then(function(obj) {
-      // Cheating a little bit to avoid going through Google. 
+      // Cheating a little bit to avoid going through Google.
       // Just call the redirect URL directly e.g.
       // https://willscott.github.io/freedom-oauth-relay/oauth-relay.html#state=freedom.oauth.redirect.handler0.05948500754311681&access_token=ya29.rADhKXAGx0fJfB0Vx5ibQUSmMvcK9GYVZBLId42Tvn9-aQEBD5HEsbKh-5Kj_D-j09wD5axgoIkadA&token_type=Bearer&expires_in=3600
 
-      /**
+      /*
       var url = "https://accounts.google.com/o/oauth2/auth?" +
         "client_id="+clientId+"&" +
         "response_type=token&" +
         "scope=email%20" + encodeURIComponent("https://www.googleapis.com/auth/userinfo.profile") + "&" +
         "redirect_uri=" + encodeURIComponent(obj.redirect) + "&" +
         "state=" + encodeURIComponent(obj.state);
-      **/
+      */
       var url = obj.redirect+"#state="+encodeURIComponent(obj.state)+
                   "&access_token=thisisanaccesstoken";
 
-      return o.launchAuthFlow(url, obj);
+      return o.launchAuthFlow(url, obj, true);
     }).then(function(url) {
       //console.log(url);
       expect(url).toEqual(jasmine.any(String));
@@ -55,5 +59,16 @@ module.exports = function (oa, pageauths, redirectURIs, setup) {
     });
 
   });
-  
+
+  it("Fails if interactive=false and not redirected to uri", function (done) {
+    var o = oauth();
+    o.initiateOAuth(redirectURIs).then(function(obj) {
+      var url = "http://error.com";
+      var launchAuthFlowPromise = o.launchAuthFlow(url, obj, false);
+      return launchAuthFlowPromise;
+    }).catch(function(error) {
+      done();
+    });
+  });
+
 };


### PR DESCRIPTION
This new test case checks that if the interactive parameter to launchAuthFlow is false, and the user is not redirected to the expected redirect url, then launchAuthFlow fails.

For this test, I had to modify jasmine.DEFAULT_TIMEOUT_INTERVAL to be 6000 ms, instead of the default 3000 ms.  This is because for tab authentication in Firefox and Chrome, if 5000 ms passes with a successful redirect, we close the tab and reject the promise returned by launchAuthFlow.  I tried using the jasmine.clock().tick(5000) to invoke this timeout, but that was not working.  I even made a simple test case to check on the jasmine clock behavior which I think should pass but times out instead:
```
  it("async test", function (done) {
    jasmine.clock().install();
    setTimeout(function() {
      done();
    }, 5000);
    jasmine.clock().tick(6000);
  });
```