### PR TITLE
Abort oauth flow after 5 seconds if interactive==false and no redirect

### DIFF
--- a/providers/oauth/oauth.localpageauth.js
+++ b/providers/oauth/oauth.localpageauth.js
@@ -4,6 +4,9 @@ var PromiseCompat = require('es6-promise').Promise;
 var oAuthRedirectId = 'freedom.oauth.redirect.handler';
 
 var loadedOnStartup = false;
+
+var TIMEOUT = 5000;
+
 /**
  * If there is redirection back to the page, and oAuthRedirectID is set,
  * then report the auth and close the window.
@@ -86,7 +89,7 @@ LocalPageAuth.prototype.launchAuthFlow = function(authUrl, stateObj, interactive
         delete this.listeners[stateObj.state];
         continuation(undefined, 'Error launching auth flow');
       }
-    }.bind(this), 5000);
+    }.bind(this), TIMEOUT);
   }
 };
 

--- a/providers/oauth/oauth.localpageauth.js
+++ b/providers/oauth/oauth.localpageauth.js
@@ -65,7 +65,7 @@ LocalPageAuth.prototype.initiateOAuth = function(redirectURIs, continuation) {
  * @method launchAuthFlow
  * @param {String} authUrl - The URL that initiates the auth flow.
  * @param {Object.<string, string>} stateObj - The return value from initiateOAuth
- * @param {Boolean} interactive - Whether to launch an interactive flow (ignored)
+ * @param {Boolean} interactive - Whether to launch an interactive flow
  * @param {Function} continuation - Function to call when complete
  *    Expected to see a String value that is the response Url containing the access token
  */
@@ -76,6 +76,18 @@ LocalPageAuth.prototype.launchAuthFlow = function(authUrl, stateObj, interactive
   window.addEventListener("storage", listener, false);
   // Start 'er up
   window.open(authUrl);
+
+  if (interactive === false) {
+    setTimeout(function() {
+      if (this.listeners[stateObj.state]) {
+        // Listener has not been deleted, indicating oauth has completed.
+        window.removeEventListener(
+            "storage", this.listeners[stateObj.state], false);
+        delete this.listeners[stateObj.state];
+        continuation(undefined, 'Error launching auth flow');
+      }
+    }.bind(this), 5000);
+  }
 };
 
 /**
@@ -84,6 +96,7 @@ LocalPageAuth.prototype.launchAuthFlow = function(authUrl, stateObj, interactive
  * http://tutorials.jenkov.com/html5/local-storage.html#storage-events
  * @param {Function} continuation function to call with result
  * @param {Object.<string, string>} stateObj the return value from initiateOAuth
+
  * @param {Object} msg storage event
  */
 LocalPageAuth.prototype.storageListener = function(continuation, stateObj, msg) {

--- a/providers/oauth/oauth.remotepageauth.js
+++ b/providers/oauth/oauth.remotepageauth.js
@@ -3,6 +3,8 @@ var PromiseCompat = require('es6-promise').Promise;
 
 var oAuthRedirectId = 'freedom.oauth.redirect.handler';
 
+var TIMEOUT = 5000;
+
 function RemotePageAuth() {
   "use strict";
   this.listeners = {};
@@ -90,7 +92,7 @@ RemotePageAuth.prototype.launchAuthFlow = function(authUrl, stateObj, interactiv
           console.warn(e);
         }
       }
-    }.bind(this), 5000);
+    }.bind(this), TIMEOUT);
   }
 };
 

--- a/providers/oauth/oauth.remotepageauth.js
+++ b/providers/oauth/oauth.remotepageauth.js
@@ -47,7 +47,7 @@ RemotePageAuth.prototype.initiateOAuth = function(redirectURIs, continuation) {
  * @method launchAuthFlow
  * @param {String} authUrl - The URL that initiates the auth flow.
  * @param {Object.<string, string>} stateObj - The return value from initiateOAuth
- * @param {Boolean} interactive - Whether to launch an interactive flow (ignored)
+ * @param {Boolean} interactive - Whether to launch an interactive flow
  * @param {Function} continuation - Function to call when complete
  *    Expected to see a String value that is the response Url containing the access token
  */
@@ -65,8 +65,10 @@ RemotePageAuth.prototype.launchAuthFlow = function(authUrl, stateObj, interactiv
     frame.contentWindow.postMessage(stateObj.state, '*');
   }.bind(this));
 
+  var hasCredentials = false;
   window.addEventListener('message', function (frame, msg) {
     if (msg.data && msg.data.key && msg.data.url && this.listeners[msg.data.key]) {
+      hasCredentials = true;
       this.listeners[msg.data.key](msg.data.url);
       delete this.listeners[msg.data.key];
       try {
@@ -76,6 +78,20 @@ RemotePageAuth.prototype.launchAuthFlow = function(authUrl, stateObj, interactiv
       }
     }
   }.bind(this, frame), false);
+
+  if (interactive === false) {
+    setTimeout(function() {
+      if (hasCredentials === false) {
+        continuation(undefined, 'Error launching auth flow');
+        delete this.listeners[stateObj.state];
+        try {
+          document.body.removeChild(frame);
+        } catch (e) {
+          console.warn(e);
+        }
+      }
+    }.bind(this), 5000);
+  }
 };
 
 /**


### PR DESCRIPTION
Tested with "grunt test".  Some storage tests have been failing and continue to fail, but this makes the oauth tests all pass