### PR TITLE
Lazy module loading

### DIFF
--- a/spec/helper/environment.js
+++ b/spec/helper/environment.js
@@ -44,6 +44,14 @@ EnvironmentTest.prototype.testRequire = function (url) {
   });
 };
 
+EnvironmentTest.prototype.testBrokenDependency = function () {
+  var p = new Promise(function(resolve, reject) {
+    freedom['broken'].onError(resolve.bind(null, 'failed'));
+  });
+  var x = freedom['broken']();
+  return p;
+};
+
 
 /** REGISTER **/
 if (typeof freedom !== 'undefined') {

--- a/spec/helper/environment.json
+++ b/spec/helper/environment.json
@@ -9,7 +9,14 @@
   "api": {
     "environment": {
       "testCrypto": {"type": "method", "value":[], "ret": "object"},
-      "testRequire": {"type": "method", "value":["string"], "ret": "string"}
+      "testRequire": {"type": "method", "value":["string"], "ret": "string"},
+      "testBrokenDependency": {"type": "method", "value":[], "ret": "object"}
+    }
+  },
+  "dependencies": {
+    "broken": {
+      "url": "broken.json",
+      "api": "doNothing"
     }
   }
 }

--- a/spec/providers/coreIntegration/environment.integration.src.js
+++ b/spec/providers/coreIntegration/environment.integration.src.js
@@ -44,12 +44,33 @@ module.exports = function (setup) {
     });
   });
 
-  it("handles dynamic require failures", function (done) {
+  it("handles dynamic require with invalid manifest", function (done) {
     moduleEnv.testRequire('relative://spec/helper/friend.js').then(function (ret) {
       expect(ret).toEqual('failed');
       done();
     }, function (ret) {
       expect(ret).toEqual(true);
+      expect(true).toEqual(false);
+      done();
+    });
+  });
+
+  it("handles dynamic require with missing source file", function (done) {
+    moduleEnv.testRequire('relative://spec/helper/broken.json').then(function (ret) {
+      expect(ret).toEqual('success');
+      done();
+    }, function (err) {
+      expect(true).toEqual(false);
+      done();
+    });
+  });
+
+  it("handles static dependency construction failures", function (done) {
+    moduleEnv.testBrokenDependency().then(function(ret) {
+      expect(ret).toEqual('failed');
+      done();
+    }, function(err) {
+      expect(err).toBeUndefined();
       expect(true).toEqual(false);
       done();
     });

--- a/src/link/frame.js
+++ b/src/link/frame.js
@@ -70,7 +70,7 @@ Frame.prototype.toString = function() {
  */
 Frame.prototype.setupListener = function() {
   var onMsg = function(msg) {
-    if (msg.data.src !== 'in') {
+    if (msg.data.src && msg.data.src !== 'in') {
       this.emitMessage(msg.data.flow, msg.data.message);
     }
   }.bind(this);
@@ -128,7 +128,7 @@ Frame.prototype.setupFrame = function() {
       this.obj = frame;
       this.emit('started');
     }
-    if (msg.data.src !== 'out') {
+    if (msg.data.src && msg.data.src !== 'out') {
       this.emitMessage(msg.data.flow, msg.data.message);
     }
   }.bind(this, frame.contentWindow);

--- a/src/moduleinternal.js
+++ b/src/moduleinternal.js
@@ -375,7 +375,6 @@ ModuleInternal.prototype.mapProxies = function (manifest) {
  * @param {String[]} scripts The URLs of the scripts to load.
  */
 ModuleInternal.prototype.loadScripts = function (from, scripts) {
-  // TODO(salomegeo): add a test for failure.
   var importer = function (script, resolve, reject) {
     try {
       this.config.global.importScripts(script);
@@ -421,6 +420,7 @@ ModuleInternal.prototype.loadScripts = function (from, scripts) {
       var script = this.config.global.document.createElement('script');
       script.src = url;
       script.addEventListener('load', resolve, true);
+      script.addEventListener('error', reject, true);
       this.config.global.document.body.appendChild(script);
     }.bind(this);
   }
@@ -444,6 +444,12 @@ ModuleInternal.prototype.tryLoad = function (importer, url) {
     this.debug.error("Error loading " + url, e);
     this.debug.error("If the stack trace is not useful, see https://" +
         "github.com/freedomjs/freedom/wiki/Debugging");
+    // This event is caught in Module, which will then respond to any messages
+    // for the provider with short-circuit errors.
+    this.emit(this.externalChannel, {
+      type: 'error'
+    });
+    throw e;
   }.bind(this));
 };
 


### PR DESCRIPTION
Prior to this change, all dependencies specified in a module's
manifest were loaded and started before that module could start.
With this change, the main module is loaded immediately, and each
dependency is only loaded after its constructor is called.
This design makes startup faster, and reduces memory usage for
projects that contain optional modules.

This change does not alter any explicit API, but it does change
the semantics of modules that perform actions before their
constructor is called.  Any such actions will now be delayed until
after the first constructor call.  I am not aware of any such
modules currently in existence.