### PR TITLE
make xhrRetriever resource loader synchronous (fix for Chrome change)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "node-json-minify": "^1.0.0",
     "phantomjs-prebuilt": "^2.1.9",
     "request": "^2.74.0",
-    "webrtc-adapter": "1.4.0"
+    "webrtc-adapter": "0.0.7"
   },
   "scripts": {
     "test": "grunt ci --verbose",

--- a/src/resource.js
+++ b/src/resource.js
@@ -344,7 +344,7 @@ Resource.prototype.xhrRetriever = function (url, resolve, reject) {
     }
   }.bind(this, resolve, reject), false);
   ref.overrideMimeType("application/json");
-  ref.open("GET", url, true);
+  ref.open("GET", url, false);
   ref.send();
 };
 


### PR DESCRIPTION
Fix #319 

Hopefully it's okay to make xhrRetriever synchronous, as that seems to be what Chrome wants.