### PR TITLE
explicitly check for defined navigator object in core.battery

### DIFF
--- a/providers/core/core.battery.js
+++ b/providers/core/core.battery.js
@@ -1,7 +1,10 @@
 /*globals navigator*/
 /*jshint node:true*/
 var PromiseCompat = require('es6-promise').Promise;
-var nav = navigator;
+var nav = false;
+if (typeof navigator !== 'undefined') {
+  nav = navigator;
+}
 
 var BatteryProvider = function(cap, dispatchEvent) {
   "use strict";


### PR DESCRIPTION
This is a fix for environments without the navigator object (such as node), which can fail (trying to refer to undefined) with the prior logic.