### PR TITLE
ensure nav/win are false if navigator/window undefined

### DIFF
--- a/providers/core/core.online.js
+++ b/providers/core/core.online.js
@@ -9,8 +9,9 @@
 // Window object.
 
 var PromiseCompat = require('es6-promise').Promise;
-var nav = navigator;
-var win = window;
+// Alias navigator/window if defined, else set to false
+var nav = typeof navigator !== 'undefined' && navigator;
+var win = typeof window !== 'undefined' && window;
 
 var OnlineProvider = function(cap, dispatchEvent) {
   "use strict";


### PR DESCRIPTION
I was working on cutting new releases and found that core integration tests were failing because the environment was referring to undefined variables. This tweak fixes that, and then I'll cut a release here and in the firefox and chrome flavors.

For the flavors, I think the only thing to do is add the provider to entry (https://github.com/freedomjs/freedom-for-firefox/commit/129bab93e2b3089ee533e61cb057555fbfd5e1d7, https://github.com/freedomjs/freedom-for-chrome/commit/98aa7a230092bf21d7c2507fae7a3fac912a7442) and bump the freedom version dependency as appropriate, as this is a fairly simple provider. Let me know if I'm missing something though - thanks!